### PR TITLE
ensure 'cd $dir' happens before the command to be run in terminal.bundle

### DIFF
--- a/PluginDirectories/1/terminal.bundle/plugin.py
+++ b/PluginDirectories/1/terminal.bundle/plugin.py
@@ -66,8 +66,7 @@ def run(command):
         ascript = ascript_currentdir + '''
         tell application "Terminal"
             activate
-            do script "cd " & dir
-            do script {0} in front window
+            do script "cd " & dir & "; " & {0}
         end tell
         '''.format(asquote(command))
     else:
@@ -79,8 +78,7 @@ def run(command):
                     activate current session
                     launch session "Default Session"
                     tell the last session
-                        write text "cd " & dir
-                        write text {0}
+                        write text "cd " & dir & "; " & {0}
                     end tell
             end tell
         end tell


### PR DESCRIPTION
When I use the Terminal plugin, the `cd` happens _after_ the command to be run in Terminal.app. This change puts the two commands into one line, ensuring they run in the correct sequence.
