### PR TITLE
run any command starting with '$' in terminal.bundle

### DIFF
--- a/PluginDirectories/1/terminal.bundle/plugin.py
+++ b/PluginDirectories/1/terminal.bundle/plugin.py
@@ -31,15 +31,17 @@ def get_html(command):
   """%(getuser(), command)
 
 def results(parsed, original_query):
+    do_check = original_query[0] != '$'
     command = parsed['~command'] if parsed else original_query
-    if command[0] not in '~/.' and not is_valid_command(command.split(' ')[0]):
-        return None
+    if do_check:
+      if command[0] not in '~/.' and not is_valid_command(command.split(' ')[0]):
+          return None
     dict = {
         "title": "$ {0}".format(command),
         "run_args": [command],
         "html": get_html(command)
     }
-    if parsed==None:
+    if do_check and parsed == None:
         dict['dont_force_top_hit'] = True
     return dict
 


### PR DESCRIPTION
`is_valid_command` relies on `whereis`, which doesn't detect (for example) brew-installed utilities and aliases. This commit skips the `is_valid_command` check for any command prefixed with `$`, and forces it to the top.
