### PR TITLE
Update URL of Warehouse used in pypi.bundle

### DIFF
--- a/PluginDirectories/1/pypi.bundle/options.json
+++ b/PluginDirectories/1/pypi.bundle/options.json
@@ -6,7 +6,7 @@
             "key": "server",
             "options": [
                 {"text": "https://pypi.python.org (CheeseShop)", "value": "cheeseshop"},
-                {"text": "https://warehouse.python.org (Warehouse)", "value": "warehouse"},
+                {"text": "https://pypi.org (Warehouse)", "value": "warehouse"},
                 {"text": "http://localhost:3141 (devpi)", "value": "devpi"}
             ]
         }

--- a/PluginDirectories/1/pypi.bundle/plugin.py
+++ b/PluginDirectories/1/pypi.bundle/plugin.py
@@ -19,7 +19,7 @@ def results(parsed, original_query):
 
     # Set server URL
     if server == 'warehouse':
-        url_template = 'https://warehouse.python.org/search/project/?q={0}'
+        url_template = 'https://pypi.org/search/?q={0}'
     elif server == 'devpi':
         url_template = 'http://localhost:3141/+search?query={0}'
     else:


### PR DESCRIPTION
URL of Warehouse is changed from https://warehouse.python.org to https://pypi.org.