### PR TITLE
fix caniuse example

### DIFF
--- a/PluginDirectories/1/CanIUse.bundle/examples.txt
+++ b/PluginDirectories/1/CanIUse.bundle/examples.txt
@@ -1,4 +1,4 @@
 CIU ~caniusequery(query here)
 Can I use ~caniusequery(query here)
 can i use ~caniusequery(query here)
-caniuse ~caniusequeryquery here)
+caniuse ~caniusequery(query here)


### PR DESCRIPTION
missing opening parenthesis