### PR TITLE
Fix for framework not loading

### DIFF
--- a/FlashlightApp/SpotlightSIMBL/SpotlightSIMBL.xcodeproj/project.pbxproj
+++ b/FlashlightApp/SpotlightSIMBL/SpotlightSIMBL.xcodeproj/project.pbxproj
@@ -769,13 +769,18 @@
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = NO;
 				GCC_PREFIX_HEADER = "";
+				HEADER_SEARCH_PATHS = "$(SRCROOT)/../FlashlightKit";
 				INFOPLIST_FILE = SpotlightSIMBL/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Application Support/SIMBL/Plugins/";
+				INSTALL_PATH = "/Library/Application Support/MacEnhance/Plugins/";
 				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks";
+				OTHER_LDFLAGS = (
+					"-rpath",
+					"@loader_path/",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.nateparrott.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				SKIP_INSTALL = YES;
+				SKIP_INSTALL = NO;
 				SYMROOT = "$(PROJECT_DIR)/build";
 				SYSTEM_FRAMEWORK_SEARCH_PATHS = "$(inherited) $(SYSTEM_LIBRARY_DIR)/PrivateFrameworks";
 				WRAPPER_EXTENSION = bundle;
@@ -799,13 +804,18 @@
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = NO;
 				GCC_PREFIX_HEADER = "";
+				HEADER_SEARCH_PATHS = "$(SRCROOT)/../FlashlightKit";
 				INFOPLIST_FILE = SpotlightSIMBL/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Application Support/SIMBL/Plugins/";
+				INSTALL_PATH = "/Library/Application Support/MacEnhance/Plugins/";
 				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks";
+				OTHER_LDFLAGS = (
+					"-rpath",
+					"@loader_path/",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.nateparrott.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				SKIP_INSTALL = YES;
+				SKIP_INSTALL = NO;
 				SYMROOT = "$(PROJECT_DIR)/build";
 				SYSTEM_FRAMEWORK_SEARCH_PATHS = "$(inherited) $(SYSTEM_LIBRARY_DIR)/PrivateFrameworks";
 				WRAPPER_EXTENSION = bundle;


### PR DESCRIPTION
For some reason starting on 10.15.4, dyld has a problem with finding a plugins framework search path. Not sure what changed but adding a linker flag fixes the issue. 